### PR TITLE
Refactor: modularize logic, extract config, and restructure runtime g…

### DIFF
--- a/animals_web_generator.py
+++ b/animals_web_generator.py
@@ -7,12 +7,15 @@ HTML template with the generated content, and writes the final HTML to a new fil
 """
 
 import json
-from typing import Any
 
-HTML_FILE = "animals_template.html"
-JSON_FILE = "animals_data.json"
-ANIMAL_HTML_FILE = "animals.html"
-PLACEHOLDER = "__REPLACE_ANIMALS_INFO__"
+from config import (
+    PLACEHOLDER,
+    JSON_FILE,
+    ATTRIBUTE,
+    SUB_ATTRIBUTE,
+    HTML_FILE,
+    ANIMAL_HTML_FILE,
+)
 
 
 def load_data(file_path: str, is_json: bool = False) -> str | dict:
@@ -30,6 +33,31 @@ def load_data(file_path: str, is_json: bool = False) -> str | dict:
     except (IOError, FileNotFoundError, json.JSONDecodeError) as e:
         print(f"Error loading file {file_path}: {e}")
         return "" if not is_json else {}
+
+
+def group_by_attribute(
+    animals: dict, attribute: str, sub_attribute: str = ""
+) -> dict[str, list[dict]]:
+    """
+    Groups a list of animals by a specified attribute, optionally using a sub-attribute.
+
+    :param animals: List of animal dictionaries to be grouped.
+    :param attribute: Top-level attribute key to group by.
+    :param sub_attribute: Optional nested attribute key within the top-level attribute.
+    :return: Dictionary where keys are attribute values and values are lists of matching animals.
+    """
+    grouped = {}
+    for animal in animals:
+        if sub_attribute:
+            key = animal.get(attribute, {}).get(sub_attribute, "Unknown")
+        else:
+            key = animal.get(attribute, "Unknown")
+
+        if key not in grouped:
+            grouped[key] = []
+        grouped[key].append(animal)
+
+    return grouped
 
 
 def save_data(file_path: str, html: str, is_json: bool = False) -> None:
@@ -131,32 +159,89 @@ def serialize_animal(animal_obj: dict) -> str:
     return generate_animal_card(name, scientific_name, body_html)
 
 
-def replace_animals_info() -> str:
+def replace_placeholder_with_html_content(html: str, output: str) -> str:
     """
     Replaces the animal information placeholder in the HTML template
     with formatted animal data from the JSON file.
 
     :return: HTML string with animal information inserted.
     """
+
+    if PLACEHOLDER not in html:
+        print(f"Error: Placeholder '{PLACEHOLDER}' not found in HTML template.")
+        return html
+    return html.replace(PLACEHOLDER, output)
+
+
+def get_user_choice_with_answers(skin_types: list[str]) -> str:
+    """
+    Prompts the user to select a skin type from a list of options.
+
+    :param skin_types: A list of available skin types.
+    :return: The skin type selected by the user.
+    """
+    skin_types = sorted(skin_types)
+    print("** Available skin types **")
+    for skin in skin_types:
+        print(f"- {skin}")
+
+    while True:
+        choice = input("Enter a skin type: ").strip()
+        if choice in skin_types:
+            return choice
+        print("Invalid choice. Please select one from the list above.")
+
+
+def generate_html_by_filtered_attribute(animal_data: list[dict], skin_type: str) -> str:
+    """
+    Generates the HTML for a list of animals filtered by a specific skin type.
+
+    :param animal_data: A list of animal dictionaries to display.
+    :param skin_type: The skin type used to filter animals.
+    :return: HTML string containing the formatted animal cards.
+    """
     output = ""
-    html_without_animals = load_data(HTML_FILE)
-    animals_data = load_data(JSON_FILE, True)
+    output += f"<h2>Filtered by: {skin_type}</h2>"
+    for animal in animal_data:
+        output += serialize_animal(animal)
+    return output
 
-    for animal_obj in animals_data:
-        output += serialize_animal(animal_obj)
 
-    html_with_animals = html_without_animals.replace(PLACEHOLDER, output)
-    return html_with_animals
+def get_filtered_animals_html() -> str:
+    """
+    Loads animal data, groups it by a given attribute, asks the user to choose a skin type,
+    and returns the HTML string for the animals matching that skin type.
+
+    :return: HTML string containing cards for animals of the selected skin type.
+    """
+    animals = load_data(JSON_FILE, is_json=True)
+    grouped = group_by_attribute(animals, ATTRIBUTE, SUB_ATTRIBUTE)
+    skin_type = get_user_choice_with_answers(list(grouped.keys()))
+    return generate_html_by_filtered_attribute(grouped[skin_type], skin_type)
+
+
+def render_and_save_html(animal_html: str) -> None:
+    """
+    Loads the HTML template, replaces its placeholder with the provided animal HTML content,
+    and saves the final HTML to a file.
+
+    :param animal_html: HTML string with the filtered animal cards to be inserted.
+    :return: None
+    """
+    html_template = load_data(HTML_FILE)
+    final_html = replace_placeholder_with_html_content(html_template, animal_html)
+    save_data(ANIMAL_HTML_FILE, final_html)
 
 
 def main() -> None:
     """
-    Main function that orchestrates the replacement and saving of animal HTML content.
+    Main function that orchestrates loading data, filtering animals by user-selected skin type,
+    generating HTML, and saving the final result to a file.
 
     :return: None
     """
-    animal_html = replace_animals_info()
-    save_data(ANIMAL_HTML_FILE, animal_html)
+    animal_html = get_filtered_animals_html()
+    render_and_save_html(animal_html)
 
 
 if __name__ == "__main__":

--- a/config.py
+++ b/config.py
@@ -1,0 +1,7 @@
+HTML_FILE = "animals_template.html"
+JSON_FILE = "animals_data.json"
+ANIMAL_HTML_FILE = "animals.html"
+PLACEHOLDER = "__REPLACE_ANIMALS_INFO__"
+
+ATTRIBUTE = "characteristics"
+SUB_ATTRIBUTE = "skin_type"

--- a/style.css
+++ b/style.css
@@ -15,7 +15,10 @@ h1 {
     font-weight: bold;
 }
 
-
+h2 {
+    font-weight: lighter;
+    margin: 35px 0 0 20px;
+}
 
 body {
     font-family: 'Roboto', 'Helvetica Neue', Helvetica, Arial, sans-serif;


### PR DESCRIPTION
…rouping by skin_type for HTML rendering

- Moved constants into a separate config module
- Moving CSS into a seperate style.css file
- Split main logic into smaller, testable functions
- Changed runtime behavior to first group animals by skin_type before generating HTML
- Improved readability with clear docstrings and type hints throughout